### PR TITLE
refactored repeathandler customization in the Pages module, #728

### DIFF
--- a/packages/enketo-core/src/js/page.js
+++ b/packages/enketo-core/src/js/page.js
@@ -9,6 +9,7 @@ import config from 'enketo/config';
 import events from './event';
 import { getSiblingElement, getAncestors } from './dom-utils';
 import 'jquery-touchswipe';
+import reasons from './reasons';
 
 /**
  * @typedef {import('./form').Form} Form

--- a/packages/enketo-core/src/js/page.js
+++ b/packages/enketo-core/src/js/page.js
@@ -252,6 +252,22 @@ export default {
             events.AddRepeat().type,
             (event) => {
                 this._updateAllActive();
+
+                // ---------- Custom OC --------------
+                /*
+                 * The only thing we want to change in this function for OC,
+                 * is to NOT flip to the next page when a repeat is the same as a page and
+                 * and a new repeat instance is created,
+                 * while there are empty reason-for-change fields.
+                 */
+                if (
+                    event.target.getAttribute('role') === 'page' &&
+                    !reasons.validate()
+                ) {
+                    this.toggleButtons();
+                }
+                // ------- End of Custom OC ----------
+
                 // Don't flip if the user didn't create the repeat with the + button.
                 // or if is the default first instance created during loading.
                 // except if the new repeat is actually the first page in the form, or contains the first page

--- a/packages/enketo-core/src/js/reasons.js
+++ b/packages/enketo-core/src/js/reasons.js
@@ -1,4 +1,4 @@
-import { t } from './translator';
+import { t } from 'enketo/translator';
 import events from './event';
 
 const range = document.createRange();

--- a/packages/enketo-express/public/js/src/module/controller-webform-oc.js
+++ b/packages/enketo-express/public/js/src/module/controller-webform-oc.js
@@ -23,7 +23,7 @@ import records from './records-queue';
 import formCache from './form-cache';
 import FieldSubmissionQueue from './field-submission-queue';
 import rc from './controller-webform';
-import reasons from './reasons';
+import reasons from 'enketo-core/src/js/reasons';
 import { replaceMediaSources, replaceModelMediaSources } from './media';
 
 let fieldSubmissionQueue;

--- a/packages/enketo-express/public/js/src/module/page.js
+++ b/packages/enketo-express/public/js/src/module/page.js
@@ -1,8 +1,5 @@
 import pageModule from 'enketo-core/src/js/page';
-import { getAncestors } from 'enketo-core/src/js/dom-utils';
 import $ from 'jquery';
-import events from './event';
-import reasons from 'enketo-core/src/js/reasons';
 import settings from './settings';
 import gui from './gui';
 

--- a/packages/enketo-express/public/js/src/module/page.js
+++ b/packages/enketo-express/public/js/src/module/page.js
@@ -31,59 +31,6 @@ pageModule.flipToPageContaining = function ($e) {
     this.$toc.parent().find('.pages-toc__overlay').click();
 };
 
-/*
- * The only thing we want to change in this function for OC,
- * is to NOT flip to the next page when a repeat is the same as a page and
- * and a new repeat instance is created,
- * while there are empty reason-for-change fields.
- */
-pageModule.setRepeatHandlers = function () {
-    this.form.view.html.addEventListener(events.AddRepeat().type, (event) => {
-        this._updateAllActive();
-
-        // ---------- Custom OC --------------
-        if (
-            event.target.getAttribute('role') === 'page' &&
-            !reasons.validate()
-        ) {
-            this.toggleButtons();
-        }
-        // ------- End of Custom OC ----------
-
-        // Don't flip if the user didn't create the repeat with the + button.
-        // or if is the default first instance created during loading.
-        // except if the new repeat is actually the first page in the form, or contains the first page
-        if (
-            event.detail.trigger === 'user' ||
-            this.activePages[0] === event.target ||
-            getAncestors(this.activePages[0], '.or-repeat').includes(
-                event.target
-            )
-        ) {
-            this.flipToPageContaining($(event.target));
-        } else {
-            this._toggleButtons();
-        }
-    });
-
-    this.form.view.html.addEventListener(
-        events.RemoveRepeat().type,
-        (event) => {
-            // if the current page is removed
-            // note that that.current will have length 1 even if it was removed from DOM!
-            if (this.current && this.current.closest('html')) {
-                this._updateAllActive();
-                let $target = $(event.target).prev();
-                if ($target.length === 0) {
-                    $target = $(event.target);
-                }
-                // is it best to go to previous page always?
-                this.flipToPageContaining($target);
-            }
-        }
-    );
-};
-
 // const originalPageModuleNext = pageModule._next;
 
 // We don't use the original call, because OC only wants to (sometimes) block strict validation (not regular non-strict)

--- a/packages/enketo-express/public/js/src/module/page.js
+++ b/packages/enketo-express/public/js/src/module/page.js
@@ -2,7 +2,7 @@ import pageModule from 'enketo-core/src/js/page';
 import { getAncestors } from 'enketo-core/src/js/dom-utils';
 import $ from 'jquery';
 import events from './event';
-import reasons from './reasons';
+import reasons from 'enketo-core/src/js/reasons';
 import settings from './settings';
 import gui from './gui';
 

--- a/packages/enketo-express/public/js/src/module/repeat.js
+++ b/packages/enketo-express/public/js/src/module/repeat.js
@@ -3,7 +3,7 @@ import repeatModule from 'enketo-core/src/js/repeat';
 import $ from 'jquery';
 import events from './event';
 import settings from './settings';
-import reasons from './reasons';
+import reasons from 'enketo-core/src/js/reasons';
 import { t } from './translator';
 import gui from './gui';
 

--- a/packages/enketo-express/widget/discrepancy-note/dn-widget.js
+++ b/packages/enketo-express/widget/discrepancy-note/dn-widget.js
@@ -7,7 +7,7 @@ import settings from '../../public/js/src/module/settings';
 import events from '../../public/js/src/module/event';
 import fileManager from '../../public/js/src/module/file-manager';
 import { Form } from '../../public/js/src/module/form';
-import reasons from '../../public/js/src/module/reasons';
+import reasons from 'enketo-core/src/js/reasons';
 
 let currentUser;
 let users;


### PR DESCRIPTION
@kkrumlian, @gushil, @pbowen-oc, as discussed, here is an example (an exceptionally nice one tbh) to demonstrate the kind of refactoring I propose to do in the monorepo.

The previous approach was taken to be able to keep using the official enketo-core npm module without forking it. This is no longer required with the monorepo.

Advantages:
+ reduced change of surprises if `enketo/enketo` updates this function in the enketo-core package
+ less change of confusion if OC is trying to identify and fix a bug in this function (since the function exists in 2 places, where one is a complete or partial overwrite)
+ less code (both original and overwritten functions exist in the JS bundle in enketo-express-oc)
+ much easier to identify customizations by looking at the diff with `enketo/enketo`. If an existing function is customized, the customization shows where it occurs (instead of somewhere else).

Disadvantage:
- increased change of merge conflicts when merging from enketo/enketo (but that may be seen as an advantage because it flags potential bugs created by the merge if the function in enketo-core changes substantially and the overwrite no longer works)
- some 3-10 hours of work to do this refactoring plus additional testing load by OC

When refactoring is done the whole `page.js` file in enketo-express would be removed as all its customizations would have moved to enketo-core.