### PR TITLE
Fixed translation cache access when the translation content is changed

### DIFF
--- a/packages/enketo-express/public/js/src/module/translator.js
+++ b/packages/enketo-express/public/js/src/module/translator.js
@@ -87,7 +87,11 @@ const localize = (container, lng) => {
         })
         .then(() => {
             list.forEach((el) => {
-                const key = el.dataset.i18n;
+                let key = el.dataset.i18n;
+                // translation key for element with i18nNumber is i18n-i18nNumber
+                if (el.dataset.i18nNumber) {
+                    key = `${key}-${el.dataset.i18nNumber}`;
+                }
                 if (key) {
                     let options = {};
                     // quick hack for __icon__ replacement
@@ -103,10 +107,19 @@ const localize = (container, lng) => {
                         };
                     }
 
-                    // Update cache only if the translation is new or has changed
-                    const translationText = t(key, options);
-                    if (!cache[key] || translationText !== cache[key]) {
-                        cache[key] = translationText;
+                    // Insert cache only if the translation is new
+                    if (!cache[key]) {
+                        let translationKey = key;
+                        // translationKey for element with i18nNumber is i18n without i18nNumber
+                        if (el.dataset.i18nNumber) {
+                            translationKey = key.substring(
+                                0,
+                                translationKey.length -
+                                    el.dataset.i18nNumber.toString().length -
+                                    1
+                            );
+                        }
+                        cache[key] = t(translationKey, options);
                     }
 
                     // This assumes that if the element has a placeholder, that's the thing that

--- a/packages/enketo-express/public/js/src/module/translator.js
+++ b/packages/enketo-express/public/js/src/module/translator.js
@@ -89,32 +89,39 @@ const localize = (container, lng) => {
             list.forEach((el) => {
                 const key = el.dataset.i18n;
                 if (key) {
-                    if (!cache[key]) {
-                        let options = {};
-                        // quick hack for __icon__ replacement
-                        if (el.dataset.i18nIcon) {
-                            options = {
-                                icon: `<span class="icon ${el.dataset.i18nIcon}"> </span>`,
-                                interpolation: { escapeValue: false },
-                            };
-                        }
-                        if (el.dataset.i18nNumber) {
-                            options = {
-                                number: el.dataset.i18nNumber,
-                            };
-                        }
-                        cache[key] = t(key, options);
+                    let options = {};
+                    // quick hack for __icon__ replacement
+                    if (el.dataset.i18nIcon) {
+                        options = {
+                            icon: `<span class="icon ${el.dataset.i18nIcon}"> </span>`,
+                            interpolation: { escapeValue: false },
+                        };
                     }
+                    if (el.dataset.i18nNumber) {
+                        options = {
+                            number: el.dataset.i18nNumber,
+                        };
+                    }
+
+                    // Update cache only if the translation is new or has changed
+                    const translationText = t(key, options);
+                    if (!cache[key] || translationText !== cache[key]) {
+                        cache[key] = translationText;
+                    }
+
                     // This assumes that if the element has a placeholder, that's the thing that
                     // needs to be localized, since placeholders are only used on form controls,
                     // and the textContent of a form control is never translatable.
+                    const translationCache = cache[key];
                     if (el.placeholder) {
-                        el.placeholder = cache[key];
+                        el.placeholder = translationCache;
                     } else if (el.dataset.i18nIcon) {
                         el.textContent = '';
-                        el.append(range.createContextualFragment(cache[key]));
+                        el.append(
+                            range.createContextualFragment(translationCache)
+                        );
                     } else {
-                        el.textContent = cache[key];
+                        el.textContent = translationCache;
                     }
                 }
             });


### PR DESCRIPTION
Closes #

The problem occured when editing the form (that already submitted before) and the page with multiple selectpickers in repeating group is always showing the wrong select text.

From my observation, it is caused by selectpicker using i18n translation with i18nNumber involved.
We will have same translations for all selectpicker widgets because all widgets have same i18n data eventhough it has different i18nNumber.


This select instances
```
<group_nm7ec42  enk:ordinal="1" >
	<multiselect2>a b c</multiselect2>
</group_nm7ec42>
<group_nm7ec42  enk:ordinal="2" >
	<multiselect2>a b</multiselect2>
</group_nm7ec42>
```
will give us
![image](https://github.com/user-attachments/assets/0302232f-0a56-4703-8874-e71f19e9ac40)

It is supposed to give us
![image](https://github.com/user-attachments/assets/d815b6c7-b640-4fce-b2b9-e2fc243ce10f)


#### I have verified this PR works with

-   [ ] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [x] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?
The solution that minimize cache key access, translation call and just adding one string comparison.
Already tried the solultion in selectpicker but that is not an optimal one.

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?
I don't think there is any. All tests are passed.

#### Do we need any specific form for testing your changes? If so, please attach one.
No.