### PR TITLE
Removing canvasreload handler that caused signature filename differences

### DIFF
--- a/packages/enketo-core/src/widget/draw/draw-widget.js
+++ b/packages/enketo-core/src/widget/draw/draw-widget.js
@@ -229,13 +229,6 @@ class DrawWidget extends Widget {
                     })
                     .click();
 
-                $(canvas).on('canvasreload', () => {
-                    if (that.cache) {
-                        that.pad
-                            .fromObjectURL(that.cache)
-                            .then(that._updateValue.bind(that, false));
-                    }
-                });
                 that.enable();
             })
             .catch((error) => {
@@ -598,7 +591,6 @@ class DrawWidget extends Widget {
             canvas.width = canvas.offsetWidth * ratio;
             canvas.height = canvas.offsetHeight * ratio;
             canvas.getContext('2d').scale(ratio, ratio);
-            $(canvas).trigger('canvasreload');
         }
     }
 


### PR DESCRIPTION
Removing canvasreload handler that caused signature filename differences between form xml string and form page element and subsequently caused form failed to upload signature.

Closes #https://jira.openclinica.com/browse/OC-20354

#### I have verified this PR works with

-   [x] Online form submission
-   [ ] Offline form submission
-   [ ] Saving offline drafts
-   [ ] Loading offline drafts
-   [ ] Editing submissions
-   [ ] Form preview
-   [ ] None of the above

#### What else has been done to verify that this works as intended?

#### Why is this the best possible solution? Were any other approaches considered?

#### How does this change affect users? Describe intentional changes to behavior and behavior that could have accidentally been affected by code changes. In other words, what are the regression risks?

#### Do we need any specific form for testing your changes? If so, please attach one.
