### PR TITLE
OC-27867 Fix iOS double-tap issue on select_one in field-list groups

### DIFF
--- a/packages/enketo-core/src/js/page.js
+++ b/packages/enketo-core/src/js/page.js
@@ -500,8 +500,13 @@ export default {
             .eq(0)
             .trigger('fakefocus');
 
-        // focus on element
-        pageEl.focus();
+        // Focusing the field-list group container on iOS Safari causes it to
+        // render extra blank space inside the div, creating a layout shift when
+        // the user first taps a radio button (tap lands in wrong position).
+        // goToTarget() already focuses the first input, so skip this for field-list groups.
+        if (!pageEl.classList.contains('or-appearance-field-list')) {
+            pageEl.focus();
+        }
 
         pageEl.scrollIntoView();
     },

--- a/packages/enketo-core/test/spec/page.spec.js
+++ b/packages/enketo-core/test/spec/page.spec.js
@@ -72,6 +72,54 @@ describe('Pages mode', () => {
         });
     });
 
+    describe('_focusOnFirstQuestion', () => {
+        /** @type {import('sinon').SinonSandbox} */
+        let sandbox;
+
+        beforeEach(() => {
+            sandbox = sinon.createSandbox();
+        });
+
+        afterEach(() => {
+            sandbox.restore();
+        });
+
+        it('does not call focus() on field-list group page element', () => {
+            const form = loadForm('groups-pages.xml');
+            form.init();
+
+            const fieldListPage = form.view.html.querySelector(
+                '.or-appearance-field-list'
+            );
+            const focusSpy = sandbox.spy(fieldListPage, 'focus');
+
+            form.pages.flipToPageContaining([fieldListPage]);
+
+            expect(focusSpy).not.to.have.been.called;
+        });
+
+        it('calls focus() on non-field-list page element', () => {
+            const form = loadForm('groups-pages.xml');
+            form.init();
+
+            // Flip to a field-list page first so the non-field-list target
+            // is not the current page when the spy is set up
+            const fieldListPage = form.view.html.querySelector(
+                '.or-appearance-field-list'
+            );
+            form.pages.flipToPageContaining([fieldListPage]);
+
+            const questionPage = form.view.html.querySelector(
+                '.question[role="page"]'
+            );
+            const focusSpy = sandbox.spy(questionPage, 'focus');
+
+            form.pages.flipToPageContaining([questionPage]);
+
+            expect(focusSpy).to.have.been.called;
+        });
+    });
+
     // TODO: this should be in toc.spec.js, but the functionality is not
     // implemented there either, and it may be confusing to test functionality
     // of one module in the test module for another.


### PR DESCRIPTION
## Summary

- On iOS Safari, tapping a radio button inside a `field-list` group required two taps: the first tap was not registered, the screen scrolled to show the header, and the question background turned yellow
- Root cause: `_focusOnFirstQuestion` calls `pageEl.focus()` on the field-list group container div (which has `tabindex`). iOS Safari responds by rendering extra blank space inside the div — visible as a blank row below the last radio option. When the user taps, iOS transitions focus from the container to the radio input, collapsing that space. The resulting layout shift moves the tap target, so the tap misses the radio button
- Fix: skip `pageEl.focus()` for field-list group elements (`or-appearance-field-list`). `goToTarget()` already focuses the first input in the group, so focusing the container is redundant and harmful on iOS

## Additional observations

- The blank row is only visible in **portrait orientation**. In landscape, the field-list group is shorter (less text wrapping) and falls below iOS's threshold for adding the scroll affordance, so the first tap works correctly
- Removing the `field-list` appearance or the group entirely also eliminates the issue, confirming the container focus as the trigger

## Test plan

- [ ] Open a form with a `select_one` inside a group with `field-list` appearance on iPhone (Safari)
- [ ] Verify no blank row appears below the last radio option on page load
- [ ] Verify a single tap selects the radio option correctly
- [ ] Verify the same behaviour in both portrait and landscape orientation
- [ ] Verify page navigation still works correctly for non-field-list pages (single-question pages)