### PR TITLE
OC-27867 Fix iOS Safari swallowing first tap on field-list radio/checkbox

### DIFF
--- a/packages/enketo-core/src/js/form.js
+++ b/packages/enketo-core/src/js/form.js
@@ -1533,7 +1533,24 @@ Form.prototype.goToTarget = function (target, options = {}) {
         );
 
         if (input != null) {
-            input.focus();
+            const isRadioOrCheckbox =
+                input.type === 'radio' || input.type === 'checkbox';
+            const isFieldListPage = target.classList.contains(
+                'or-appearance-field-list'
+            );
+
+            // OC-27867: on iOS Safari, calling focus() on a radio/checkbox right
+            // when a field-list page appears (before the user has tapped anything)
+            // breaks the user's next tap on that same button: it highlights but
+            // never actually gets selected. So on page flip, skip focus() for
+            // this one case. We still fire "applyfocus" below, since other
+            // widgets (date, time, geo, etc.) rely on that event to work correctly.
+            const skipFocus =
+                options.isPageFlip && isFieldListPage && isRadioOrCheckbox;
+
+            if (!skipFocus) {
+                input.focus();
+            }
             input.dispatchEvent(events.ApplyFocus());
         }
 

--- a/packages/enketo-core/test/forms/focus.xml
+++ b/packages/enketo-core/test/forms/focus.xml
@@ -33,6 +33,9 @@
                         <repeat-field />
                         <repeat-field2 />
                     </repeat-page>
+                    <select-radio-page>
+                        <select-radio-field />
+                    </select-radio-page>
                     <meta>
                         <instanceID/>
                     </meta>
@@ -42,6 +45,7 @@
             <bind nodeset="/data/field-page" />
             <bind nodeset="/data/relevant-page" relevant="/data/field-page = '1'" />
             <bind nodeset="/data/select-page" />
+            <bind nodeset="/data/select-radio-page/select-radio-field" />
 
             <bind nodeset="/data/group-page/group-readonly-empty-field" readonly="true()" />
             <bind nodeset="/data/group-page/group-readonly-calc-field" readonly="true()" calculate="'calculated'" />
@@ -162,6 +166,24 @@
                     </item>
                 </select>
             </repeat>
+        </group>
+
+        <group ref="/data/select-radio-page" appearance="field-list">
+            <label>Select radio page</label>
+
+            <!-- No "minimal" appearance: renders as plain native radio inputs
+                 (not the select-desktop widget), matching the OC-27867 iOS bug. -->
+            <select ref="/data/select-radio-page/select-radio-field">
+                <label>Select radio field</label>
+                <item>
+                    <value>1</value>
+                    <label>One</label>
+                </item>
+                <item>
+                    <value>2</value>
+                    <label>Two</label>
+                </item>
+            </select>
         </group>
     </h:body>
 </h:html>

--- a/packages/enketo-core/test/forms/focus.xml
+++ b/packages/enketo-core/test/forms/focus.xml
@@ -173,7 +173,7 @@
 
             <!-- No "minimal" appearance: renders as plain native radio inputs
                  (not the select-desktop widget), matching the OC-27867 iOS bug. -->
-            <select ref="/data/select-radio-page/select-radio-field">
+            <select1 ref="/data/select-radio-page/select-radio-field">
                 <label>Select radio field</label>
                 <item>
                     <value>1</value>
@@ -183,7 +183,7 @@
                     <value>2</value>
                     <label>Two</label>
                 </item>
-            </select>
+            </select1>
         </group>
     </h:body>
 </h:html>

--- a/packages/enketo-core/test/spec/form.spec.js
+++ b/packages/enketo-core/test/spec/form.spec.js
@@ -2179,6 +2179,46 @@ describe('Focus', () => {
             });
         });
     });
+
+    describe('OC-27867: does not focus() a radio/checkbox on a field-list page flip', () => {
+        /** @type {HTMLElement} */
+        let fieldListGroup;
+
+        /** @type {HTMLInputElement} */
+        let radioInput;
+
+        beforeEach(() => {
+            fieldListGroup = formElement.querySelector(
+                '*[name="/data/select-radio-page"]'
+            );
+            radioInput = formElement.querySelector(
+                'input[name="/data/select-radio-page/select-radio-field"]'
+            );
+        });
+
+        it('does not focus the radio when flipping to its field-list page', () => {
+            form.goToTarget(fieldListGroup, { isPageFlip: true });
+
+            expect(document.activeElement).to.not.equal(radioInput);
+        });
+
+        it('still dispatches applyfocus, so other widgets keep working', () => {
+            let applyfocusFired = false;
+            radioInput.addEventListener('applyfocus', () => {
+                applyfocusFired = true;
+            });
+
+            form.goToTarget(fieldListGroup, { isPageFlip: true });
+
+            expect(applyfocusFired).to.equal(true);
+        });
+
+        it('still focuses the radio when it is not a page flip (e.g. jumping to a validation error)', () => {
+            form.goToTarget(fieldListGroup);
+
+            expect(document.activeElement).to.equal(radioInput);
+        });
+    });
 });
 
 function mockChoiceNameForm() {


### PR DESCRIPTION
## Summary

Follow-up to #258 (OC-27867). That PR fixed one iOS Safari bug in field-list groups: focusing the group *container* caused extra blank space to render, shifting the layout so the user's first tap landed in the wrong place.

This PR fixes a second, related bug left in place by that fix: `Form.prototype.goToTarget` in `form.js` always calls real `focus()` on the first form control when a page appears, regardless of appearance. On iOS Safari, calling `focus()` on a radio/checkbox this way — right before the user's very first tap on that same control — causes the tap to be swallowed: the touch highlight shows, but no click/change event ever fires, so the option never gets selected.

A real-device screen recording confirmed this: tapping the already-focused first radio in a field-list group did nothing, for several seconds, with no other visible interaction.

## Fix

Skip the native `focus()` call in `goToTarget()` specifically when flipping to a field-list page whose first control is a radio or checkbox. `applyfocus` still dispatches unconditionally, so widgets that depend on it (date, time, geo, select-desktop, etc.) are unaffected.

## Test plan

- [x] Added tests in `form.spec.js` (new radio fixture in `focus.xml`) covering: `focus()` skipped on field-list page flip, `applyfocus` still dispatched, and `focus()` still applied when it's not a page flip (e.g. jumping to a validation error).
- [x] Full enketo-core suite passes locally (1121/1121, 6 skipped).
- [ ] Live iOS Safari retest of the exact "Never" tap scenario from the original bug report, once deployed to staging.